### PR TITLE
Return empty str if no header found - makes .trim not throw

### DIFF
--- a/inbox.js
+++ b/inbox.js
@@ -47,5 +47,6 @@ function renderRow(obj) {
     for (var i = 0; i < headers.length; i++) {
       if (headers[i].name === header) return headers[i].value
     }
+    return ''
   }
 }


### PR DESCRIPTION
If no Subject header <code>getHeader(obj, 'Subject').trim()</code> throws. Maybe a better fix to check return type, but since it's the only call to getHeader this was the quick one :smirk_cat: 
